### PR TITLE
Change order post by latest entry first

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+# Used for testing orders
+gem 'orderly'
+# User authentication
 gem 'devise'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,9 @@ GEM
     nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
+    orderly (0.0.3)
+      capybara (>= 1.1)
+      rspec (>= 2.14)
     orm_adapter (0.5.0)
     pg (1.0.0)
     public_suffix (3.0.2)
@@ -153,6 +156,10 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -234,6 +241,7 @@ DEPENDENCIES
   devise
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  orderly
   pg
   puma (~> 3.7)
   rails (~> 5.1.1)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,7 @@ class PostsController < ApplicationController
   end
 
   def index
-    @posts = Post.all
+    @posts = Post.all.order("created_at DESC")
   end
 
   private

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,10 +4,14 @@
   <%= link_to 'Edit profile', edit_user_registration_path, :class => 'navbar-link' %> |
   <%= link_to "Logout", destroy_user_session_path, method: :delete, :class => 'navbar-link'  %>
   <br>
-  <% @posts.each do |post| %>
-    <p><%=post.created_at.strftime("%H:%M %F") %></p>
-    <p><%= simple_format(post.message) %></p>
-  <% end %>
+  <ul>
+    <% @posts.each do |post| %>
+      <li>
+        <p><%=post.created_at.strftime("%H:%M %F") %></p>
+        <p><%= simple_format(post.message) %></p>
+      </li>
+    <% end %>
+  </ul>
 
   <%= link_to new_post_path do %>
     New post

--- a/spec/features/user_can_submit_posts_spec.rb
+++ b/spec/features/user_can_submit_posts_spec.rb
@@ -22,4 +22,10 @@ RSpec.feature "Post", type: :feature do
     expect(page).to have_content(time)
   end
 
+  scenario "Posts are shown latest first" do
+    newPostAndSubmit("Old Message")
+    newPostAndSubmit("New Message")
+    expect("New Message").to appear_before("Old Message")
+  end
+
 end


### PR DESCRIPTION
Resolved conflicts on index.html.erb

Have added a new gem orderly for testing.
Used orderly to check that one content appears after another
Updated tests to include new specHelper function
Made it so the posts are latest first on the screen